### PR TITLE
fix: 修复考试信息查询不全

### DIFF
--- a/app/service/zfService/login.go
+++ b/app/service/zfService/login.go
@@ -43,7 +43,7 @@ func login(username string, password string) (*model.User, error) {
 	} else {
 		URL = apis.CAPTCHA_BREAKER_URL
 	}
-	captcha, err := f.Get(URL + "?request=" + f.Cookie[0].Value + "&route=" + f.Cookie[1].Value)
+	captcha, err := f.Get(URL + "?session=" + f.Cookie[0].Value + "&route=" + f.Cookie[1].Value)
 	if err != nil {
 		return nil, err
 	}

--- a/app/service/zfService/zfService.go
+++ b/app/service/zfService/zfService.go
@@ -25,7 +25,6 @@ func GetLessonsTable(stu *model.User, year string, term string) (interface{}, er
 }
 func GetExamInfo(stu *model.User, year string, term string) (interface{}, error) {
 	var result model.ExamInfo
-	resultMap := make(map[string]*model.Exam)
 	for i := 0; i < 7; i++ {
 		res, err := fetchTermRelatedInfo(stu, zf.ZfExamInfo(), year, term, i)
 		if err != nil {
@@ -38,12 +37,7 @@ func GetExamInfo(stu *model.User, year string, term string) (interface{}, error)
 			//return nil, err
 		}
 		examInfo := model.TransformExamInfo(&f)
-		for _, v := range examInfo {
-			resultMap[v.ExamTime] = v
-		}
-	}
-	for _, v := range resultMap {
-		result = append(result, v)
+		result = append(result, examInfo...)
 	}
 	sort.SliceStable(result, func(i, j int) bool {
 		return result[i].ExamTime > result[j].ExamTime


### PR DESCRIPTION
考试信息有一步是:
- 将考试信息转化为一个map :考试时间 -> 考试信息

但是未开放不可查的考试就会彼此覆盖
因为时间都是: "未开放不可查"